### PR TITLE
chore: add CI/CD pipeline and bump version to 1.3.2

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__noodle-perplexity-mcp__perplexity_ask",
+      "mcp__perplexity-mcp__perplexity_ask"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,36 @@
+# CODEOWNERS for noodle-perplexity-mcp
+# This file defines who must review changes to specific files/directories
+# Format: pattern owner1 owner2 ...
+
+# Global owners - review all changes
+* @fahd-noodleseed
+
+# CI/CD and GitHub configuration
+/.github/ @fahd-noodleseed
+.github/workflows/ @fahd-noodleseed
+
+# Package configuration and dependencies
+package.json @fahd-noodleseed
+package-lock.json @fahd-noodleseed
+tsconfig.json @fahd-noodleseed
+
+# Core API and server files
+/src/services/perplexityApi.ts @fahd-noodleseed
+/src/mcp-server/server.ts @fahd-noodleseed
+/src/utils/internal/requestContext.ts @fahd-noodleseed
+/src/utils/internal/errorHandler.ts @fahd-noodleseed
+
+# Security-sensitive files
+/src/utils/security/ @fahd-noodleseed
+*.env* @fahd-noodleseed
+.npmrc @fahd-noodleseed
+
+# Documentation requiring review
+README.md @fahd-noodleseed
+SECURITY.md @fahd-noodleseed
+CLAUDE.md @fahd-noodleseed
+LICENSE @fahd-noodleseed
+
+# Build and distribution
+/dist/ @fahd-noodleseed
+/scripts/ @fahd-noodleseed

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,109 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  # Build and Test
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run tests
+      run: npm test
+      continue-on-error: true  # Remove when tests exist
+
+    - name: Build
+      run: npm run build
+
+    - name: Upload build
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist
+        path: dist/
+
+  # Check if we should publish (only on main)
+  check-publish:
+    name: Check Version
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    outputs:
+      publish: ${{ steps.check.outputs.publish }}
+      version: ${{ steps.check.outputs.version }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Check version
+      id: check
+      run: |
+        VERSION=$(node -p "require('./package.json').version")
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+        if npm view noodle-perplexity-mcp@$VERSION version 2>/dev/null; then
+          echo "Version $VERSION already published"
+          echo "publish=false" >> $GITHUB_OUTPUT
+        else
+          echo "Version $VERSION ready to publish"
+          echo "publish=true" >> $GITHUB_OUTPUT
+        fi
+
+  # Manual approval gate
+  approve:
+    name: Approve Release
+    runs-on: ubuntu-latest
+    needs: check-publish
+    if: needs.check-publish.outputs.publish == 'true'
+    environment: production
+
+    steps:
+    - name: Request approval
+      run: echo "🚀 Ready to publish v${{ needs.check-publish.outputs.version }} - awaiting manual approval"
+
+  # Publish to npm
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: [check-publish, approve]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Install and build
+      run: |
+        npm ci
+        npm run build
+
+    - name: Publish to npm
+      run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: Tag release
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git tag v${{ needs.check-publish.outputs.version }}
+        git push origin v${{ needs.check-publish.outputs.version }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security
+
+## Reporting Issues
+
+If you find a security vulnerability, please report it via:
+- GitHub Issues: https://github.com/fahd-noodleseed/perplexity-mcp-server/issues
+- Or create a private security advisory on GitHub
+
+## Best Practices
+
+- Never commit API keys to version control
+- Store `PERPLEXITY_API_KEY` in environment variables
+- Keep dependencies up to date with `npm update`
+- Use the latest version of this package
+
+## Open Source Notice
+
+This tool is provided as-is for the community. Users are responsible for:
+- Securing their own API keys
+- Following their organization's security policies
+- Auditing the code if needed for production use
+
+## Updates
+
+Security updates will be released as patch versions when needed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noodle-perplexity-mcp",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A Perplexity API Model Context Protocol (MCP) server that unlocks Perplexity's search-augmented AI capabilities for LLM agents. Features robust error handling, secure input validation, and transparent reasoning with the showThinking parameter. Built with type safety, modular architecture, and production-ready utilities.",
   "main": "dist/index.js",
   "files": [
@@ -16,6 +16,7 @@
     "rebuild": "npm run clean && npm run build",
     "tree": "ts-node --esm scripts/tree.ts",
     "start": "node dist/index.js",
+    "test": "echo \"Tests will be added soon\" && exit 0",
     "prepublishOnly": "npm run rebuild"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
Add automated CI/CD pipeline with manual approval gate for npm publishing.

## Changes
- ✅ GitHub Actions workflow for CI/CD
- 🔒 CODEOWNERS for required reviews  
- 📝 Lightweight SECURITY.md
- 🧪 Test script placeholder
- 📦 Version bump to 1.3.2 for testing

## How it works
1. Build and test on every push/PR
2. Check if version is new (not already on npm)
3. Request manual approval for publishing
4. Publish to npm after approval
5. Auto-create git tag

## Next Steps
1. Merge this PR
2. Configure 'production' environment in GitHub settings with approval requirements
3. Pipeline will detect v1.3.2 and request approval for publishing