### PR TITLE
chore: Bump version to 1.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![TypeScript](https://img.shields.io/badge/TypeScript-^5.8.3-blue.svg)](https://www.typescriptlang.org/)
 [![Model Context Protocol](https://img.shields.io/badge/MCP%20SDK-^1.15.0-green.svg)](https://modelcontextprotocol.io/)
-[![Version](https://img.shields.io/badge/Version-1.3.2-blue.svg)](./package.json)
+[![Version](https://img.shields.io/badge/Version-1.3.3-blue.svg)](./package.json)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Status](https://img.shields.io/badge/Status-Stable-green.svg)](https://github.com/fahd-noodleseed/perplexity-mcp-server/issues)
 [![npm](https://img.shields.io/npm/v/noodle-perplexity-mcp)](https://www.npmjs.com/package/noodle-perplexity-mcp)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noodle-perplexity-mcp",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A Perplexity API Model Context Protocol (MCP) server that unlocks Perplexity's search-augmented AI capabilities for LLM agents. Features robust error handling, secure input validation, and transparent reasoning with the showThinking parameter. Built with type safety, modular architecture, and production-ready utilities.",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
## Summary
Bump version to 1.3.3 for npm republish with updated documentation.

## Changes
- ✅ Bumped package.json version from 1.3.2 to 1.3.3
- ✅ Updated README version badge to match

## Reason
Need to publish updated package with corrected README documentation that accurately reflects the current tool implementations.

🤖 Generated with [Claude Code](https://claude.ai/code)