### PR TITLE
chore: Bump version to 1.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perplexity-mcp-server",
-  "version": "1.2.1",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "perplexity-mcp-server",
-      "version": "1.2.1",
+      "version": "1.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noodle-perplexity-mcp",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "A Perplexity API Model Context Protocol (MCP) server that unlocks Perplexity's search-augmented AI capabilities for LLM agents. Features robust error handling, secure input validation, and transparent reasoning with the showThinking parameter. Built with type safety, modular architecture, and production-ready utilities.",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
## Summary
Bump version to 1.3.4 following repository cleanup and consistency fixes.

## Changes
- Version bumped from 1.3.3 to 1.3.4
- Package successfully published to npm

This version includes the cleanup changes from PR #5:
- Removed unnecessary files and directories
- Fixed naming inconsistencies to use 'noodle-perplexity-mcp' consistently
- Updated CLAUDE.md with cleaner structure

🤖 Generated with [Claude Code](https://claude.ai/code)